### PR TITLE
Add Python .gitignore and CI test matrix for multiple Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,14 +9,17 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
 
       - name: Run hello world
         run: python hello.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,59 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+*.egg
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# IDE files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Testing / Coverage
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# mypy
+.mypy_cache/


### PR DESCRIPTION
## Summary

- **Add a comprehensive Python .gitignore** covering common artifacts like `__pycache__/`, `*.py[cod]`, `.eggs/`, `dist/`, `build/`, virtual environments, IDE files, OS files, and testing/coverage artifacts
- **Add CI test matrix for multiple Python versions** (3.8, 3.9, 3.10, 3.11, 3.12) using a matrix strategy in the GitHub Actions workflow, matching the README stated Python 3.8+ compatibility

Closes #3

## Test plan
- [ ] Verify .gitignore properly excludes common Python artifacts
- [ ] Verify CI workflow runs tests against all 5 Python versions (3.8, 3.9, 3.10, 3.11, 3.12)
- [ ] Verify python hello.py output test passes on all matrix versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)