### PR TITLE
CI and .gitignore improvements: Python version updates and fail-fast strategy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ wheels/
 *.egg
 
 # Virtual environments
-.env
+.env/
 .venv
 env/
 venv/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple Python hello world application.
 
 ### Requirements
 
-- Python 3.8+
+- Python 3.9+
 
 ### How to Run
 


### PR DESCRIPTION
## Summary

Addresses all tasks from issue #5:

- **Add fail-fast: false to CI matrix strategy**: All Python version builds now run to completion even if one version fails, helping identify all version-specific issues in a single CI run.
- **Add Python 3.13 to the CI test matrix**: Python 3.13 (latest stable release) is now included in the test matrix.
- **Drop Python 3.8 from the CI matrix**: Python 3.8 reached end-of-life in October 2024. Removed from test matrix and updated README compatibility statement from 3.8+ to 3.9+.
- **Review .env entry in .gitignore**: Changed .env to .env/ (directory only) so the project can use .env dotenv configuration files if needed, while still ignoring .env/ virtual environment directories.

## Test plan
- [ ] Verify CI workflow runs successfully with Python 3.9, 3.10, 3.11, 3.12, and 3.13
- [ ] Verify fail-fast: false allows all matrix jobs to complete independently
- [ ] Verify .env files are no longer ignored (only .env/ directories)
- [ ] Confirm README accurately reflects Python 3.9+ requirement

Closes #5