### PR TITLE
Fix .venv gitignore consistency and add Python 3.14 to CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ wheels/
 
 # Virtual environments
 .env/
-.venv
+.venv/
 env/
 venv/
 ENV/


### PR DESCRIPTION
## Summary
- Add trailing `/` to `.venv` entry in `.gitignore` for consistency with other virtual environment directory entries (`.env/`, `env/`, `venv/`, `ENV/`)
- Add Python 3.14 to the CI test matrix in `.github/workflows/test.yml`

Closes #7

## Test plan
- [ ] Verify `.gitignore` correctly ignores `.venv/` directory
- [ ] Verify CI matrix includes Python 3.14 and all tests pass across all Python versions
- [ ] Confirm no regressions in existing CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)