### PR TITLE
Add continue-on-error for Python 3.14 CI matrix entry

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        include:
+          - python-version: '3.14'
+            continue-on-error: true
+    continue-on-error: ${{ matrix.continue-on-error || false }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add continue-on-error: true for the Python 3.14 matrix entry in .github/workflows/test.yml
- This is a defensive measure to prevent upstream Python 3.14 instability from blocking PRs while maintaining visibility into compatibility
- Uses the include matrix directive to selectively apply continue-on-error only to Python 3.14

Closes #9

## Test plan
- [ ] Verify CI matrix still includes all Python versions (3.9-3.14)
- [ ] Verify Python 3.14 job has continue-on-error: true while other versions do not
- [ ] Confirm all existing CI checks continue to pass
- [ ] Verify that if Python 3.14 fails, it does not block the overall workflow

Generated with Claude Code (https://claude.com/claude-code)