### PR TITLE
Remove continue-on-error for Python 3.14 CI matrix entry

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
-        include:
-          - python-version: '3.14'
-            continue-on-error: true
-    continue-on-error: ${{ matrix.continue-on-error || false }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Remove the `include` directive and `continue-on-error` job-level expression for Python 3.14 from `.github/workflows/test.yml`
- Python 3.14 has reached stable release and CI checks consistently pass, so this defensive configuration is no longer needed
- This is a cleanup task following up on PR #10 and Issue #9

Closes #11

## Test plan
- [ ] Verify CI matrix still includes all Python versions (3.9-3.14)
- [ ] Verify no `continue-on-error` configuration remains in the workflow
- [ ] Confirm all CI checks pass for all Python versions including 3.14
- [ ] Verify that Python 3.14 failures now properly block the workflow (as expected for a stable release)

Generated with [Claude Code](https://claude.com/claude-code)