### PR TITLE
Pin GitHub Actions to SHA versions for supply chain security

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary
- Pin `actions/checkout@v4` to its SHA commit hash (`34e114876b0b11c390a56381ad16ebd13914f8d5`)
- Pin `actions/setup-python@v5` to its SHA commit hash (`a26af69be951a213d495a4c3e4e4022e16d87065`)
- Add inline comments with tag versions next to each SHA for readability

## Motivation
This change hardens the CI pipeline against supply chain attacks by pinning GitHub Actions to immutable SHA references instead of mutable tags. Tag-based references (e.g., `@v4`) are theoretically vulnerable to tag rewriting, where a malicious actor could replace the tag to point to compromised code.

## Test plan
- [x] Verified `hello.py` output is correct locally
- [x] Verified workflow YAML syntax is valid
- [ ] CI workflow should pass on all Python versions (3.9-3.14)

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)