### PR TITLE
Add Dependabot config for automated GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Dependabot configuration for automated dependency updates.
+# Keeps pinned GitHub Action SHAs up to date by creating PRs
+# when newer versions of actions are released.
+#
+# Reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` to automatically create PRs when pinned GitHub Action SHAs have newer versions available
- Configured for weekly checks (Mondays) of the `github-actions` package ecosystem
- PRs will be labeled with `dependencies` and `github-actions` labels
- Commit messages will be prefixed with `ci` for consistency

## Motivation
PR #14 (resolving #13) pinned GitHub Actions to SHA hashes for supply chain security. However, these SHAs become stale as new action versions are released. This Dependabot configuration automates the process of keeping those dependencies current.

## Test plan
- [x] Verified `hello.py` output is correct locally in virtual environment
- [x] Verified workflow YAML syntax is valid
- [x] Validated `dependabot.yml` YAML syntax with pyyaml
- [ ] CI workflow should pass on all Python versions (3.9-3.14)

Closes #15

Generated with [Claude Code](https://claude.com/claude-code)