### PR TITLE
Change hello world references to hello Codex

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,15 +22,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Run hello world
+      - name: Run hello Codex
         run: python hello.py
 
       - name: Verify output
         run: |
           output=$(python hello.py)
-          if [ "$output" = "Hello World" ]; then
-            echo "Test passed: Output is 'Hello World'"
+          if [ "$output" = "Hello Codex" ]; then
+            echo "Test passed: Output is 'Hello Codex'"
           else
-            echo "Test failed: Expected 'Hello World', got '$output'"
+            echo "Test failed: Expected 'Hello Codex', got '$output'"
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # ds-codex-test
 Test repo for Developer Sentinel Codex integration testing
 
-## Hello World Application
+## Hello Codex Application
 
-A simple Python hello world application.
+A simple Python hello Codex application.
 
 ### Requirements
 
@@ -17,5 +17,5 @@ python hello.py
 
 This will output:
 ```
-Hello World
+Hello Codex
 ```

--- a/hello.py
+++ b/hello.py
@@ -1,9 +1,9 @@
-"""A simple Hello World application."""
+"""A simple Hello Codex application."""
 
 
 def main():
-    """Print Hello World to the console."""
-    print("Hello World")
+    """Print Hello Codex to the console."""
+    print("Hello Codex")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update `hello.py` to print `Hello Codex`
- replace remaining `world` references in README and CI workflow verification

## Test plan
- [x] Create and activate `.venv`
- [x] `python hello.py`
- [x] verify output equals `Hello Codex` (workflow-equivalent assertion)

Closes #17