### PR TITLE
Refactor greeting to a single source of truth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,26 @@ jobs:
 
       - name: Verify output
         run: |
+          expected=$(python -c "from greeting import GREETING; print(GREETING)")
           output=$(python hello.py)
-          if [ "$output" = "Hello Codex" ]; then
-            echo "Test passed: Output is 'Hello Codex'"
+          if [ "$output" = "$expected" ]; then
+            echo "Test passed: Output is '$expected'"
           else
-            echo "Test failed: Expected 'Hello Codex', got '$output'"
+            echo "Test failed: Expected '$expected', got '$output'"
             exit 1
           fi
+
+      - name: Verify README output example
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          from greeting import GREETING
+
+          readme = Path("README.md").read_text()
+          expected_block = f"This will output:\n```\n{GREETING}\n```"
+          if expected_block not in readme:
+              raise SystemExit(
+                  "README output example does not match greeting source of truth"
+              )
+          print("README output example matches GREETING constant")
+          PY

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ A simple Python hello Codex application.
 python hello.py
 ```
 
+The greeting text is defined once in `greeting.py` as `GREETING`.
+
 This will output:
 ```
 Hello Codex

--- a/greeting.py
+++ b/greeting.py
@@ -1,0 +1,3 @@
+"""Central source of truth for the app greeting."""
+
+GREETING = "Hello Codex"

--- a/hello.py
+++ b/hello.py
@@ -1,9 +1,11 @@
 """A simple Hello Codex application."""
 
+from greeting import GREETING
+
 
 def main():
     """Print Hello Codex to the console."""
-    print("Hello Codex")
+    print(GREETING)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `greeting.py` with a `GREETING` constant as the single source of truth
- update `hello.py` to print that constant instead of a duplicated string
- update CI verification to derive expected output from `GREETING` and add a README consistency check

## Test plan
- [x] Create and activate `.venv`
- [x] `python hello.py`
- [x] Run workflow-equivalent output verification logic
- [x] Verify README output block matches `GREETING`

Closes #19