### PR TITLE
Extract README consistency check into reusable test path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,16 +37,4 @@ jobs:
           fi
 
       - name: Verify README output example
-        run: |
-          python - <<'PY'
-          from pathlib import Path
-          from greeting import GREETING
-
-          readme = Path("README.md").read_text()
-          expected_block = f"This will output:\n```\n{GREETING}\n```"
-          if expected_block not in readme:
-              raise SystemExit(
-                  "README output example does not match greeting source of truth"
-              )
-          print("README output example matches GREETING constant")
-          PY
+        run: python tests/check_readme_consistency.py

--- a/tests/check_readme_consistency.py
+++ b/tests/check_readme_consistency.py
@@ -1,0 +1,25 @@
+"""Verify that README output example matches the greeting source of truth."""
+
+from pathlib import Path
+import sys
+
+# Keep import behavior consistent for local runs and CI regardless of script path.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from greeting import GREETING
+
+
+def main() -> None:
+    readme = Path("README.md").read_text()
+    expected_block = f"This will output:\n```\n{GREETING}\n```"
+    if expected_block not in readme:
+        raise SystemExit(
+            "README output example does not match greeting source of truth"
+        )
+    print("README output example matches GREETING constant")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- move README greeting consistency verification from inline workflow heredoc into `tests/check_readme_consistency.py`
- keep the exact validation behavior and messages unchanged
- update `.github/workflows/test.yml` to invoke the reusable script

## Test plan
- [x] `python hello.py`
- [x] workflow-equivalent output check command
- [x] `python tests/check_readme_consistency.py`

Closes #21