### PR TITLE
Add non-root regression coverage for README consistency check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,6 @@ jobs:
 
       - name: Verify README output example
         run: python tests/check_readme_consistency.py
+
+      - name: Verify README output example from non-root working directory
+        run: python tests/check_readme_consistency_non_root.py

--- a/tests/check_readme_consistency_non_root.py
+++ b/tests/check_readme_consistency_non_root.py
@@ -1,0 +1,38 @@
+"""Regression coverage for non-root invocation of README consistency check."""
+
+from pathlib import Path
+import subprocess
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECK_SCRIPT = ROOT / "tests" / "check_readme_consistency.py"
+SUCCESS_MESSAGE = "README output example matches GREETING constant"
+
+
+def main() -> None:
+    # Run from tests/ to ensure behavior is independent of current working dir.
+    result = subprocess.run(
+        [sys.executable, str(CHECK_SCRIPT)],
+        cwd=ROOT / "tests",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise SystemExit(
+            "README consistency check failed from non-root working directory.\n"
+            f"stdout:\n{result.stdout}\n"
+            f"stderr:\n{result.stderr}"
+        )
+
+    if SUCCESS_MESSAGE not in result.stdout:
+        raise SystemExit(
+            "README consistency check did not report expected success output "
+            "from non-root working directory."
+        )
+
+    print("README consistency check succeeds from non-root working directory")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `tests/check_readme_consistency_non_root.py` to run the README consistency script from `tests/` as a non-root working directory
- assert the existing check succeeds and keeps the expected success output
- run the new regression check in `.github/workflows/test.yml`

## Test plan
- [x] `python hello.py`
- [x] workflow-equivalent output assertion from `.github/workflows/test.yml`
- [x] `python tests/check_readme_consistency.py`
- [x] `python tests/check_readme_consistency_non_root.py`

Closes #25