### PR TITLE
Test cleanup: add explicit prefix to non-root temp subdirectory

### DIFF
--- a/tests/check_readme_consistency_non_root.py
+++ b/tests/check_readme_consistency_non_root.py
@@ -42,7 +42,7 @@ def run_check_from(cwd: Path, scenario: str) -> None:
 def main() -> None:
     run_check_from(ROOT / "tests", "tests subdirectory")
 
-    with tempfile.TemporaryDirectory(dir=ROOT) as temp_dir:
+    with tempfile.TemporaryDirectory(dir=ROOT, prefix="readme-non-root-") as temp_dir:
         run_check_from(Path(temp_dir), "temporary subdirectory")
 
 


### PR DESCRIPTION
## Summary
- set an explicit prefix for the temporary non-root test directory
- keep all existing scenarios and assertions unchanged

## Test plan
- [x] python hello.py
- [x] workflow-equivalent output assertion from .github/workflows/test.yml
- [x] python tests/check_readme_consistency.py
- [x] python tests/check_readme_consistency_non_root.py

Closes #29