### PR TITLE
Test hardening: assert temp dir prefix in non-root README regression

### DIFF
--- a/tests/check_readme_consistency_non_root.py
+++ b/tests/check_readme_consistency_non_root.py
@@ -43,6 +43,13 @@ def main() -> None:
     run_check_from(ROOT / "tests", "tests subdirectory")
 
     with tempfile.TemporaryDirectory(dir=ROOT, prefix="readme-non-root-") as temp_dir:
+        temp_dir_name = Path(temp_dir).name
+        if not temp_dir_name.startswith("readme-non-root-"):
+            raise SystemExit(
+                "Temporary directory name does not preserve expected prefix.\n"
+                f"temp_dir: {temp_dir}\n"
+                f"expected_prefix: readme-non-root-"
+            )
         run_check_from(Path(temp_dir), "temporary subdirectory")
 
 


### PR DESCRIPTION
## Summary
- add a lightweight assertion that the temporary non-root directory basename starts with `readme-non-root-`
- keep existing non-root invocation behavior and success-output assertions unchanged

## Test plan
- [x] python hello.py
- [x] workflow-equivalent output assertion from .github/workflows/test.yml
- [x] python tests/check_readme_consistency.py
- [x] python tests/check_readme_consistency_non_root.py

Closes #31